### PR TITLE
Refresh community links; fix mixed content ahead of HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="shortcut icon" href="favicon.ico" />
     <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.0/css/bootstrap-combined.min.css" rel="stylesheet">
     <link href="style.css" rel="stylesheet">
-    <script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
+    <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
     <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.0/js/bootstrap.min.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -51,7 +51,8 @@
             <div class="nav-collapse collapse">
               <ul class="nav">
                 <li class="active"><a href="#home">Home</a></li>
-                <li><a href="http://meetup.com/betaNYC" target="_blank">Join BetaNYC</a></li>
+                <li><a href="https://www.beta.nyc/" target="_blank">Join BetaNYC</a></li>
+                <li><a href="https://www.beta.nyc/donate/" target="_blank">Donate</a></li>
                 <li><a href="#ex_summary">Executive Summary</a></li>
                 <li><a href="#introduction">Introduction</a></li>
                 <li><a href="#recommendations">Recommendations</a></li>
@@ -106,7 +107,8 @@
               </p>
               <p class="lead"><em>This is the original Roadmap. As of Fall 2017, 14 of these ideas were drafted into legislation, 9 were signed into law, and another 9 became public-private partnerships. The People's Roadmap for a digital New York City is paving a path to improve our lives, provide transparency, and inform government of our desires.<br/><br/></em><br/><br/>
               </p>
-              <a class="btn btn-large btn-primary" href="https://www.beta.nyc" target="_blank">Join NYC's civic hacker movement</a>
+              <a class="btn btn-large btn-primary" href="https://www.beta.nyc/" target="_blank">Join NYC's civic hacker movement</a>
+              <a class="btn btn-large" href="https://www.beta.nyc/donate/" target="_blank">Support our work</a>
             </div>
           </div>
         </div>
@@ -194,7 +196,7 @@
 
 <p class="lead">Since 2011, the Bloomberg administration has produced three Digital Roadmaps, strategic plans to transform New York City into the world's premier digital city. While pioneering, we felt the government-created roadmap needed a more complete voice. This document is created by the people, for the people of New York City. </p>
 
-<p class="lead"><a href="http://betanyc.us" target="_blank">BetaNYC</a>, NYC's vanguard of civic technologists and civic hackers, has organized around this document to outline a future that uses technology to extend FDR's four freedoms into the 21st Century. We are members of the Code for America brigade program. We meet regularly to demystify the City's digital infrastructure, incorporate data into our projects or business, and advocate for collaborative technology that fosters dialogue and drives impact. Founded in 2009, BetaNYC is dedicated to building a connected New York City for the people, by the people, for the 21st Century.</p>
+<p class="lead"><a href="https://www.beta.nyc/" target="_blank">BetaNYC</a>, NYC's vanguard of civic technologists and civic hackers, has organized around this document to outline a future that uses technology to extend FDR's four freedoms into the 21st Century. We are members of the Code for America brigade program. We meet regularly to demystify the City's digital infrastructure, incorporate data into our projects or business, and advocate for collaborative technology that fosters dialogue and drives impact. Founded in 2009, BetaNYC is dedicated to building a connected New York City for the people, by the people, for the 21st Century.</p>
 
 <p class="lead">This roadmap is the culmination of years of active listening and engagement with New Yorkers from all backgrounds. The ideas within this guide began online. Then, these ideas were brought into public forums, community events, and workshops held in all five boroughs. This "community"-centered roadmap is a guide for future city administrations to develop smarter communities, high-speed and accessible infrastructure, lifelong learning education initiatives, programs for employment and economic mobility, and effective and open government.</p>
 
@@ -707,12 +709,12 @@ NYTM centers around its monthly events, where members gather to watch emerging c
       <div class="featurette">
         <img name="contact" id="contact" class="featurette-image pull-right" src="">
               <div class="featurette">
-        <a href="http://www.meetup.com/betanyc/messages/archive/" target="_blank">
+        <a href="https://www.beta.nyc/newsletter/" target="_blank">
           <img name="groups" id="groups" class="featurette-image pull-right" src="images/google_groups.png">
         </a>
         <h2 class="featurette-heading">Want to know more? <span class="muted">Join Us.</span></h2>
-        <p class="lead"><a href="http://betanyc.us" target="_blank">BetaNYC</a> <a href="http://meetup.com/betanyc" target="_blank">meets</a> regularly to discuss these issues and take action for impact.</p>
-        <p class="lead">Can't make it to an event? No problem. We collaborate on projects, ask for help, and post wins to our <a href="http://www.meetup.com/betanyc/messages/archive/">Meetup.com discussion list</a> or <a href="http://facebook.com/group/betanyc" target="_blank">Facebook discussion group</a>. Plug in and let's get connected.</p>
+        <p class="lead"><a href="https://www.beta.nyc/" target="_blank">BetaNYC</a> <a href="https://www.beta.nyc/events/" target="_blank">meets</a> regularly to discuss these issues and take action for impact.</p>
+        <p class="lead">Can't make it to an event? No problem. Keep up with us through our weekly newsletter, <a href="https://www.beta.nyc/newsletter/" target="_blank">This week in NYC's civic tech</a>, and <a href="https://www.beta.nyc/donate/" target="_blank">support our work with a donation</a>. Plug in and let's get connected.</p>
         <h3 class=featurette-heading3">About the authors</h3>
         <p class="lead">This document was compiled by members of BetaNYC and through individuals who attended <a href="http://www.meetup.com/nycgov/" target="_blank">NYC Digital's listening sessions</a> and <a href="http://www.meetup.com/betanyc/events/99114992/?trax_also_in_algorithm2=original&eventId=99114992&traxDebug_also_in_algorithm2_picked=original&action=detail&traxDebug_also_in_algorithm2_cookied=original" target="_blank">co-hosted events with New York Tech Meetup</a>. The primary authors were Noel Hidalgo and Jennifer Baek. They were assisted by Rebecca Williams, Kathrine Russell, Frank Hebbert, Luis Daniel, Daniel Latorre, Nathan Storey, David Osborne, Adam Greenfield, Dana Spiegel , Elizabeth Ghormley, Andrew Hoppin, Alex C-W, Lyle Mills, Mikael Hveem, Andrew Bennie, Arnaud Sahuguet, Andrew Maier. You can find a complete comment history within the <a href="https://docs.google.com/document/d/1_hN-syKJPIfPicXfuhIlcf55SrbwJLM0rTkLrmx-Be4/edit?usp=sharing" target="_blank">google drive version of this document</a>.
         <h3 class=featurette-heading3">About the copyright</h3>


### PR DESCRIPTION
Brings the site's BetaNYC community links up to 2026 and clears the one mixed-content blocker for enabling HTTPS on nycroadmap.us.

## Link changes

| Location | Was | Now |
|---|---|---|
| Nav "Join BetaNYC" | meetup.com/betaNYC | https://www.beta.nyc/ |
| Nav (new) | — | **Donate** → https://www.beta.nyc/donate/ |
| Hero (new button) | — | **Support our work** → https://www.beta.nyc/donate/ |
| Intro + Join Us `BetaNYC` | betanyc.us (dead-ish old domain) | https://www.beta.nyc/ |
| "meets regularly" | meetup.com/betanyc | https://www.beta.nyc/events/ |
| Google Groups image + "discussion list" | Meetup messages archive | https://www.beta.nyc/newsletter/ (This week in NYC's civic tech) |
| "Facebook discussion group" | facebook.com/group/betanyc (dead) | donation page |

Per Noel: no Slack links (org is moving away from Slack); promote beta.nyc and the donation page instead.

## Mixed-content fix

jQuery was loaded over hard `http://`, which browsers block on an https page (would break the collapsing nav and ToC dropdown once HTTPS is enforced). Now `https://`. The Bootstrap CDN references are protocol-relative and unaffected.

## Left alone

- Historical citations in "About the authors" (2013 Meetup event, NYC Digital listening sessions) — part of the document's record.
- The dead Universal Analytics snippet and the Google Groups featurette image — tracked as separate issues.

## Test plan (run pre-PR)

- All new targets curl-verified 200: www.beta.nyc `/`, `/donate/`, `/events/`, `/newsletter/`
- Grep confirms no remaining betanyc.us / facebook group / active-community Meetup links, and no Slack references
- Grep confirms no remaining `http://` loaded assets (script/link/img/iframe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)