### PR TITLE
2026 postscript, archival framing, remove dead analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,23 +11,6 @@
     <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.0/js/bootstrap.min.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<!-- Google Tracking -->
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-40620664-2', 'noneck.github.io');
-  ga('send', 'pageview');
-
-</script>
-<!-- End Google Tracking -->
-
-
-<!--Twitter Tracking Code Start -->
-<!--<meta property="twitter:account_id" content="46654180" />-->
-<!--Twitter Tracking Code End -->
   </head>
 
   <body>
@@ -105,7 +88,11 @@
               <p> <h1>This is the People's Roadmap to a Digital New York City</h1> </p>
               <p class="lead">Welcome to the 21st century New York, build by the people, for the people, for the digital era. In this citizen created roadmap, we outline how to humanize technology, move beyond transparency for transparency's sake, and ensure we have government technology that works for the people, built with the people.<br/><br/>
               </p>
-              <p class="lead"><em>This is the original Roadmap. As of Fall 2017, 14 of these ideas were drafted into legislation, 9 were signed into law, and another 9 became public-private partnerships. The People's Roadmap for a digital New York City is paving a path to improve our lives, provide transparency, and inform government of our desires.<br/><br/></em><br/><br/>
+              <p class="lead"><em>This is the original Roadmap. As of Fall 2017, 14 of these ideas were drafted into legislation, 9 were signed into law, and another 9 became public-private partnerships. The People's Roadmap for a digital New York City is paving a path to improve our lives, provide transparency, and inform government of our desires.<br/><br/></em>
+              </p>
+              <p class="lead"><em>2026 update: a thirteen-year review found 11 of the roadmap's 34 recommendations fully realized, with eight enacted in law or charter and three running as programs or partnerships, and another 18 partially realized. At least 16 local laws and a voter-approved Charter amendment advance ideas this roadmap championed, from putting the City Record and the City's laws online to codifying the Mayor's Office of Data Analytics and citywide participatory budgeting.<br/><br/></em>
+              </p>
+              <p class="lead">This site is preserved as a historical document. For BetaNYC's current work, visit <a href="https://www.beta.nyc/" target="_blank">beta.nyc</a>.<br/><br/>
               </p>
               <a class="btn btn-large btn-primary" href="https://www.beta.nyc/" target="_blank">Join NYC's civic hacker movement</a>
               <a class="btn btn-large" href="https://www.beta.nyc/donate/" target="_blank">Support our work</a>


### PR DESCRIPTION
Lane 1 of the roadmap refresh: brings the site's self-description current without touching its 2013 character.

## Changes

1. **2026 update in the hero**, directly under the Fall 2017 postscript, with verified numbers from BetaNYC's July 2026 impact review of all 34 recommendations: 11 fully realized (8 enacted in law or charter, 3 running as programs/partnerships), 18 partially realized, and at least 16 local laws plus a voter-approved Charter amendment advancing roadmap asks. Wording is press-safe and matches the internal report (`people/noel/work/2026-07-17-peoples-roadmap-impact-analysis.md`); when a public scorecard page ships (lane 2), the update can link to it.
2. **Archival note** in the hero: "This site is preserved as a historical document. For BetaNYC's current work, visit beta.nyc." Closes #7. The Google Groups featurette image was left as-is: no BetaNYC asset exists in `images/`, and the historical imagery reads as part of the preserved design. Reopen #7 if you want it swapped.
3. **Dead analytics removed**: the Universal Analytics snippet (UA-40620664-2, dead since Google sunset UA in July 2023, and tagged to the pre-migration noneck.github.io property) and the commented-out Twitter tracking meta. Closes #6. If traffic numbers are ever wanted, a GA4 tag can be added fresh.

## Layout check

The carousel caption is `position: static` inside a `min-height` item, so the two added paragraphs extend the translucent panel rather than overflowing the hero (verified against style.css, including the ≤767px breakpoint).

## Numbers provenance

All figures come from the 2026-07-17 impact analysis (four-researcher sweep, two-axis scoring, cross-checked against the internal Roadmap Scorecard and primary sources; the City Record attribution verified against the Mayor's 2014-08-07 press release via the Internet Archive).

Closes #6, closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)