### PR TITLE
2026 scorecard page: all 34 recommendations scored against the public record

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
             <div class="nav-collapse collapse">
               <ul class="nav">
                 <li class="active"><a href="#home">Home</a></li>
+                <li><a href="scorecard.html">2026 Scorecard</a></li>
                 <li><a href="https://www.beta.nyc/" target="_blank">Join BetaNYC</a></li>
                 <li><a href="https://www.beta.nyc/donate/" target="_blank">Donate</a></li>
                 <li><a href="#ex_summary">Executive Summary</a></li>
@@ -90,7 +91,7 @@
               </p>
               <p class="lead"><em>This is the original Roadmap. As of Fall 2017, 14 of these ideas were drafted into legislation, 9 were signed into law, and another 9 became public-private partnerships. The People's Roadmap for a digital New York City is paving a path to improve our lives, provide transparency, and inform government of our desires.<br/><br/></em>
               </p>
-              <p class="lead"><em>2026 update: a thirteen-year review found 11 of the roadmap's 34 recommendations fully realized, with eight enacted in law or charter and three running as programs or partnerships, and another 18 partially realized. At least 16 local laws and a voter-approved Charter amendment advance ideas this roadmap championed, from putting the City Record and the City's laws online to codifying the Mayor's Office of Data Analytics and citywide participatory budgeting.<br/><br/></em>
+              <p class="lead"><em>2026 update: a thirteen-year review found 11 of the roadmap's 34 recommendations fully realized, with eight enacted in law or charter and three running as programs or partnerships, and another 18 partially realized. At least 16 local laws and a voter-approved Charter amendment advance ideas this roadmap championed, from putting the City Record and the City's laws online to codifying the Mayor's Office of Data Analytics and citywide participatory budgeting. <a href="scorecard.html">See the full scorecard</a>.<br/><br/></em>
               </p>
               <p class="lead">This site is preserved as a historical document. For BetaNYC's current work, visit <a href="https://www.beta.nyc/" target="_blank">beta.nyc</a>.<br/><br/>
               </p>

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
               </p>
               <p class="lead"><em>This is the original Roadmap. As of Fall 2017, 14 of these ideas were drafted into legislation, 9 were signed into law, and another 9 became public-private partnerships. The People's Roadmap for a digital New York City is paving a path to improve our lives, provide transparency, and inform government of our desires.<br/><br/></em>
               </p>
-              <p class="lead"><em>2026 update: a thirteen-year review found 11 of the roadmap's 34 recommendations fully realized, with eight enacted in law or charter and three running as programs or partnerships, and another 18 partially realized. At least 16 local laws and a voter-approved Charter amendment advance ideas this roadmap championed, from putting the City Record and the City's laws online to codifying the Mayor's Office of Data Analytics and citywide participatory budgeting. <a href="scorecard.html">See the full scorecard</a>.<br/><br/></em>
+              <p class="lead"><em>2026 update: a thirteen-year review found 11 of the roadmap's 34 recommendations fully realized, with eight enacted in law, charter, or executive order and three running as programs or partnerships, and another 18 partially realized. At least 16 local laws and a voter-approved Charter amendment advance ideas this roadmap championed, from putting the City Record and the City's laws online to codifying the Mayor's Office of Data Analytics and citywide participatory budgeting. <a href="scorecard.html">See the full scorecard</a>.<br/><br/></em>
               </p>
               <p class="lead">This site is preserved as a historical document. For BetaNYC's current work, visit <a href="https://www.beta.nyc/" target="_blank">beta.nyc</a>.<br/><br/>
               </p>

--- a/scorecard.html
+++ b/scorecard.html
@@ -50,7 +50,7 @@
       <h1>The People's Roadmap at 13: the scorecard</h1>
       <p class="lead">In 2013, New Yorkers wrote this roadmap for an incoming administration. In 2026, with another new administration at City Hall, we scored all 34 recommendations against the public record: local laws, executive orders, city program pages, and press accounts. Every status below links to a source.</p>
 
-      <p class="lead"><strong>The count: 11 of 34 recommendations fully realized</strong> (eight enacted in law or charter, three running as programs or partnerships), <strong>another 18 partially realized</strong>, and 5 that never happened. At least 16 local laws and a voter-approved Charter amendment advance ideas this roadmap championed.</p>
+      <p class="lead"><strong>The count: 11 of 34 recommendations fully realized</strong> (eight enacted in law, charter, or executive order, three running as programs or partnerships), <strong>another 18 partially realized</strong>, four that never happened, and one that was dissolved. At least 16 local laws and a voter-approved Charter amendment advance ideas this roadmap championed.</p>
 
       <blockquote class="crown">
         <p>"In 2013, through the People's Roadmap to a Digital New York City, BetaNYC argued that New York City must put the City Record online in a machine-readable format."</p>

--- a/scorecard.html
+++ b/scorecard.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>2026 Scorecard | The People's Roadmap to a Digital New York City | BetaNYC</title>
+    <meta name="description" content="Thirteen years after BetaNYC published the People's Roadmap to a Digital New York City, we scored all 34 recommendations against the public record. 11 fully realized, 18 partially realized, and at least 16 local laws plus a Charter amendment advance ideas this roadmap championed.">
+    <link rel="shortcut icon" href="favicon.ico" />
+    <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.0/css/bootstrap-combined.min.css" rel="stylesheet">
+    <link href="style.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
+    <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.0/js/bootstrap.min.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+      .scorecard-page { padding-top: 100px; }
+      .scorecard-table td { vertical-align: top; }
+      .scorecard-table .label { white-space: nowrap; }
+      .scorecard-legend .label { margin-right: 6px; }
+      blockquote.crown { margin: 30px 0; }
+    </style>
+  </head>
+
+  <body>
+
+    <!-- NAVBAR ================================================== -->
+    <div class="navbar-wrapper">
+      <div class="container">
+        <div class="navbar navbar-inverse">
+          <div class="navbar-inner">
+            <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+            </a>
+            <a href="index.html"><div class = "appleLogo"></div></a>
+            <div class="nav-collapse collapse">
+              <ul class="nav">
+                <li><a href="index.html">Home</a></li>
+                <li class="active"><a href="scorecard.html">2026 Scorecard</a></li>
+                <li><a href="https://www.beta.nyc/" target="_blank">Join BetaNYC</a></li>
+                <li><a href="https://www.beta.nyc/donate/" target="_blank">Donate</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="container scorecard-page">
+
+      <h1>The People's Roadmap at 13: the scorecard</h1>
+      <p class="lead">In 2013, New Yorkers wrote this roadmap for an incoming administration. In 2026, with another new administration at City Hall, we scored all 34 recommendations against the public record: local laws, executive orders, city program pages, and press accounts. Every status below links to a source.</p>
+
+      <p class="lead"><strong>The count: 11 of 34 recommendations fully realized</strong> (eight enacted in law or charter, three running as programs or partnerships), <strong>another 18 partially realized</strong>, and 5 that never happened. At least 16 local laws and a voter-approved Charter amendment advance ideas this roadmap championed.</p>
+
+      <blockquote class="crown">
+        <p>"In 2013, through the People's Roadmap to a Digital New York City, BetaNYC argued that New York City must put the City Record online in a machine-readable format."</p>
+        <small>Office of the Mayor, <a href="https://web.archive.org/web/20140815042726/http://www1.nyc.gov/office-of-the-mayor/news/393-14/mayor-bill-de-blasio-signs-two-transparency-bills-law-public-private-partnership-to" target="_blank">announcing the signing of Local Laws 37 and 38 of 2014</a></small>
+      </blockquote>
+
+      <p class="scorecard-legend">
+        <span class="label label-success">Enacted</span> law or charter provision
+        <span class="label label-info">Adopted</span> running program or partnership
+        <span class="label label-warning">Partial</span> real movement, short of the ask
+        <span class="label label-inverse">Superseded</span> overtaken by events
+        <span class="label label-important">Not realized</span>
+      </p>
+
+      <table class="table table-striped scorecard-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Recommendation</th>
+            <th>Status</th>
+            <th>What happened</th>
+            <th>BetaNYC's role</th>
+            <th>Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td>1</td><td><a href="index.html#1">"We the People of NYC" petition tool</a></td><td><span class="label label-important">Not realized</span></td><td>Four Council bills, four sessions, all died in committee (2014&ndash;2025).</td><td>We backed the ask; the bills tracked it.</td><td><a href="https://intro.nyc/0614-2024" target="_blank">Int 614-2024</a></td></tr>
+          <tr><td>2</td><td><a href="index.html#2">Track FOIL requests publicly</a></td><td><span class="label label-success">Enacted</span></td><td>OpenRecords portal (2016+), mandated by Local Law 199 of 2025.</td><td>The roadmap urged the open-source codebase the City used.</td><td><a href="https://intro.nyc/1235-2025" target="_blank">LL 199/2025</a></td></tr>
+          <tr><td>3</td><td><a href="index.html#3">FOIL: "once opened, always open"</a></td><td><span class="label label-success">Enacted</span></td><td>FOIL-to-open-data review, Local Laws 7 of 2016 and 244 of 2017.</td><td>We testified through the amendment era.</td><td><a href="https://opendata.cityofnewyork.us/open-data-law/" target="_blank">Open Data Law</a></td></tr>
+          <tr><td>4</td><td><a href="index.html#4">Expand the Mayor's Office of Data Analytics</a></td><td><span class="label label-success">Enacted</span></td><td>Codified into the Charter by Local Law 222 of 2018; now the Office of Data &amp; Analytics inside OTI.</td><td>We testified for codification.</td><td><a href="https://intro.nyc/1137-2018" target="_blank">LL 222/2018</a></td></tr>
+          <tr><td>5</td><td><a href="index.html#5">Expand Code Corps</a></td><td><span class="label label-important">Not realized</span></td><td>The program vanished in the 2014 transition; no successor.</td><td>None documented.</td><td><a href="https://web.archive.org/web/20141006041814/http://www.nyc.gov/html/digital/html/codecorps/codecorps.shtml" target="_blank">2014 archive</a></td></tr>
+          <tr><td>6</td><td><a href="index.html#6">Empower NYC Digital and the Chief Digital Officer</a></td><td><span class="label label-warning">Partial</span></td><td>The CDO role ended in 2017; agency design labs emerged; OTI consolidated tech in 2022.</td><td>We stayed engaged across every version.</td><td><a href="https://www.govtech.com/workforce/nyc-chief-digital-officer-departs-amid-tech-reorganization.html" target="_blank">GovTech, 2017</a></td></tr>
+          <tr><td>7</td><td><a href="index.html#7">Municipal fiber network</a></td><td><span class="label label-warning">Partial</span></td><td>Internet Master Plan (2020) shelved in 2022; Big Apple Connect serves NYCHA; Local Law 153 of 2025 mandates recurring broadband plans.</td><td>We testified at the 2020 and 2025 hearings.</td><td><a href="https://intro.nyc/1122-2024" target="_blank">LL 153/2025</a></td></tr>
+          <tr><td>8</td><td><a href="index.html#8">Mesh networks and Digital Stewards</a></td><td><span class="label label-warning">Partial</span></td><td>RISE:NYC funded resilient mesh (2015); NYC Mesh grew community-run; no municipal program.</td><td>None documented.</td><td><a href="https://www.newamerica.org/nyc/press-releases/new-americas-resilient-mesh-wireless-project-wins-rise-nyc-competition/" target="_blank">RISE:NYC</a></td></tr>
+          <tr><td>9</td><td><a href="index.html#9">Ensure iZone's success</a></td><td><span class="label label-inverse">Superseded</span></td><td>Dissolved 2014&ndash;2017; the technology-in-schools agenda moved to CS4All.</td><td>None documented.</td><td><a href="https://www.chalkbeat.org/newyork/2014/10/9/21093073/with-changes-in-leadership-and-funding-the-splashy-izone-reaches-a-crossroads/" target="_blank">Chalkbeat, 2014</a></td></tr>
+          <tr><td>10</td><td><a href="index.html#10">Digital toolkits for schools</a></td><td><span class="label label-info">Adopted</span></td><td>Computer Science for All (2015&ndash;), now in 91% of schools; equity goals unmet.</td><td>None documented.</td><td><a href="https://www.nycfuture.org/research/ten-years-of-cs4all" target="_blank">CUF, 2025</a></td></tr>
+          <tr><td>11</td><td><a href="index.html#11">Invest in Made in NY startups</a></td><td><span class="label label-warning">Partial</span></td><td>NYCEDC vehicles continue (Catalyst Fund, Founder Fellowship); the pension-fund idea never moved.</td><td>None documented.</td><td><a href="https://edc.nyc/press-release/nycedc-executive-committee-approves-final-three-investments-nyc-catalyst-fund" target="_blank">NYCEDC</a></td></tr>
+          <tr><td>12</td><td><a href="index.html#12">Better software procurement</a></td><td><span class="label label-warning">Partial</span></td><td>PASSPort digitized the paperwork (2017+); the process itself is unreformed.</td><td>None documented.</td><td><a href="https://www.nyc.gov/site/mocs/passport/about-passport.page" target="_blank">PASSPort</a></td></tr>
+          <tr><td>13</td><td><a href="index.html#13">Digitize business permits</a></td><td><span class="label label-warning">Partial</span></td><td>NYC Business portal (2017), MyCity Business (2023); paper workflows persist.</td><td>None documented.</td><td><a href="https://www.nyc.gov/assets/sbs/downloads/pdf/about/reports/small-business-first-report.pdf" target="_blank">Small Business First</a></td></tr>
+          <tr><td>14</td><td><a href="index.html#14">Put the City Record online</a></td><td><span class="label label-success">Enacted</span></td><td>Local Law 38 of 2014; City Record Online and its open dataset are live today.</td><td><strong>Documented: the Mayor's signing release credits this roadmap by name.</strong></td><td><a href="https://intro.nyc/0363-2014" target="_blank">LL 38/2014</a></td></tr>
+          <tr><td>15</td><td><a href="index.html#15">More innovation and app challenges</a></td><td><span class="label label-warning">Partial</span></td><td>BigApps ended in 2019; NYCx faded; NYC Open Data Week endures.</td><td>Documented: we co-produce Open Data Week with the City.</td><td><a href="https://www.beta.nyc/2025/05/06/nyc-open-data-week-2025-in-review/" target="_blank">ODW 2025</a></td></tr>
+          <tr><td>16</td><td><a href="index.html#16">Overhaul DoITT; elevate the CIO/CTO</a></td><td><span class="label label-success">Enacted</span></td><td>Executive Order 3 of 2022 consolidated the tech offices into OTI under a CTO. An EO, not a law: a future mayor can undo it.</td><td>We called for the reorganization in budget testimony.</td><td><a href="https://www.nyc.gov/office-of-the-mayor/news/039-22/mayor-adams-creates-more-efficient-government-consolidating-city-tech-agencies-under-new-office" target="_blank">EO 3, 2022</a></td></tr>
+          <tr><td>17</td><td><a href="index.html#17">Look to open source practices</a></td><td><span class="label label-warning">Partial</span></td><td>A Citywide GitHub Policy (2016) and open-source city tools; the FOSS procurement act died twice.</td><td>We testified for the FOSS Act.</td><td><a href="https://beta.nyc/wp-content/uploads/2016/05/Citywide-GitHub-Policy.pdf" target="_blank">GitHub Policy</a></td></tr>
+          <tr><td>18</td><td><a href="index.html#18">More cross-agency task forces</a></td><td><span class="label label-warning">Partial</span></td><td>DART and SMART faded; the function moved into MODA and agency Open Data Coordinators.</td><td>We testified for the structures that replaced them.</td><td><a href="https://www.nyc.gov/html/om/pdf/eo/eo_306.pdf" target="_blank">EO 306</a></td></tr>
+          <tr><td>19</td><td><a href="index.html#19">Mayoral Innovation Fellows</a></td><td><span class="label label-warning">Partial</span></td><td>City Hall declined. We built the Civic Innovation Fellowship with the Manhattan Borough President in 2014; it still runs.</td><td>Documented: it is our program.</td><td><a href="https://www.beta.nyc/our-work/civic-innovation-fellows/" target="_blank">CIF</a></td></tr>
+          <tr><td>20</td><td><a href="index.html#20">Publish data in data standards</a></td><td><span class="label label-success">Enacted</span></td><td>Local Laws 106&ndash;110 of 2015 and successors; the Technical Standards Manual governs publishing.</td><td>We testified for data dictionaries; they became LL 107.</td><td><a href="https://intro.nyc/0898-2015" target="_blank">LL 107/2015</a></td></tr>
+          <tr><td>21</td><td><a href="index.html#21">Restaurant inspection data via LIVES</a></td><td><span class="label label-info">Adopted</span></td><td>The 2013 Yelp partnership; the inspection dataset is live and updating today.</td><td>None documented; it predates the roadmap.</td><td><a href="https://data.cityofnewyork.us/Health/DOHMH-New-York-City-Restaurant-Inspection-Results/43nn-pn8j" target="_blank">Dataset</a></td></tr>
+          <tr><td>22</td><td><a href="index.html#22">Grow the Open311 standard</a></td><td><span class="label label-warning">Partial</span></td><td>A read-only 311 API exists; there is still no standards-based way to submit a service request.</td><td>We build public tools on the 311 API today.</td><td><a href="https://api-portal.nyc.gov/" target="_blank">311 API</a></td></tr>
+          <tr><td>23</td><td><a href="index.html#23">Open up NYC's maps</a></td><td><span class="label label-warning">Partial</span></td><td>PLUTO freed (2013), the crime map (Local Law 39 of 2013), planimetrics on the portal.</td><td>Our community fought for PLUTO and built on it.</td><td><a href="https://www.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page" target="_blank">PLUTO</a></td></tr>
+          <tr><td>24</td><td><a href="index.html#24">Creative Commons for city content</a></td><td><span class="label label-important">Not realized</span></td><td>NYC.gov remains All Rights Reserved.</td><td>None documented.</td><td><a href="https://www.nyc.gov/home/terms-of-use.page" target="_blank">Terms of Use</a></td></tr>
+          <tr><td>25</td><td><a href="index.html#25">Citizen user-testing groups</a></td><td><span class="label label-warning">Partial</span></td><td>The Service Design Studio (2017) tests with residents project-by-project; no standing corps.</td><td>None documented.</td><td><a href="https://www.nyc.gov/site/opportunity/portfolio/service-design-studio.page" target="_blank">Studio</a></td></tr>
+          <tr><td>26</td><td><a href="index.html#26">A data literacy academy for communities</a></td><td><span class="label label-info">Adopted</span></td><td>Open Data Ambassadors, School of Data, and community board trainings deliver it.</td><td>Documented: the City calls Ambassadors "a collaboration between NYC Open Data and BetaNYC."</td><td><a href="https://opendata.cityofnewyork.us/open-data-ambassadors/" target="_blank">Ambassadors</a></td></tr>
+          <tr><td>27</td><td><a href="index.html#27">A one-stop shop for citizen information</a></td><td><span class="label label-warning">Partial</span></td><td>ACCESS NYC (2017), then MyCity (2023), which the Comptroller found is not yet a true one-stop.</td><td>None documented.</td><td><a href="https://comptroller.nyc.gov/reports/audit-report-on-the-new-york-city-office-of-technology-and-innovations-mycity-system/" target="_blank">2025 audit</a></td></tr>
+          <tr><td>28</td><td><a href="index.html#28">Notify NYC on more platforms</a></td><td><span class="label label-warning">Partial</span></td><td>An app, 13 languages, geotargeted alerts: the goal is substantially met.</td><td>None documented.</td><td><a href="https://www.nyc.gov/site/em/about/press-releases/20170922_pr_nycem-doitt-release-notify-nyc-app.page" target="_blank">App launch</a></td></tr>
+          <tr><td>29</td><td><a href="index.html#29">Equip community boards with better tools</a></td><td><span class="label label-warning">Partial</span></td><td>BoardStat (2017), a website mandate in Local Law 211 of 2018, and Civic Engagement Commission support.</td><td>Documented: we built BoardStat with the Manhattan Borough President.</td><td><a href="https://opendata.cityofnewyork.us/projects/boardstat/" target="_blank">BoardStat</a></td></tr>
+          <tr><td>30</td><td><a href="index.html#30">Expand participatory budgeting</a></td><td><span class="label label-success">Enacted</span></td><td>Charter &sect;225-a via the 2018 ballot; "The People's Money" runs citywide, still under-resourced.</td><td>We testified to the Charter Revision Commission for expansion.</td><td><a href="https://ballotpedia.org/New_York,_New_York,_Question_2,_Civic_Engagement_Commission_City_Charter_Amendment_(November_2018)" target="_blank">2018 ballot</a></td></tr>
+          <tr><td>31</td><td><a href="index.html#31">Put the Charter, Rules, and Code online</a></td><td><span class="label label-success">Enacted</span></td><td>Local Law 37 of 2014. Free online today; machine-readable open access still rides on a vendor.</td><td>Documented: we ship the open access layer ourselves.</td><td><a href="https://intro.nyc/0149-2014" target="_blank">LL 37/2014</a></td></tr>
+          <tr><td>32</td><td><a href="index.html#32">Human- and machine-readable records</a></td><td><span class="label label-warning">Partial</span></td><td>The open data amendments and Local Law 29 of 2019 cover much of it; PDFs persist.</td><td>We testified through the amendment era.</td><td><a href="https://opendata.cityofnewyork.us/open-data-law/" target="_blank">Open Data Law</a></td></tr>
+          <tr><td>33</td><td><a href="index.html#33">"Yelp.gov" for NYC agencies</a></td><td><span class="label label-important">Not realized</span></td><td>Aggregate satisfaction dashboards exist; no public rating platform.</td><td>None documented.</td><td><a href="https://www.nyc.gov/site/311reporting/311-reports/resolution-satisfaction.page" target="_blank">311 dashboard</a></td></tr>
+          <tr><td>34</td><td><a href="index.html#34">A Department of Neighborhoods</a></td><td><span class="label label-warning">Partial</span></td><td>Never a department; the Public Engagement Unit, the Civic Engagement Commission, and now the Office of Mass Engagement (EO 7, 2026) carry the function.</td><td>We argued for institutionalized engagement at the 2018 Charter Revision.</td><td><a href="https://www.nyc.gov/content/dam/nycgov/mayors-office/downloads/pdf/executive-orders/2026/eo-07.pdf" target="_blank">EO 7, 2026</a></td></tr>
+        </tbody>
+      </table>
+
+      <hr class="featurette-divider">
+
+      <h3>About this scorecard</h3>
+      <p class="lead">We assessed each recommendation on two separate questions: did the idea happen, and can we document our own role in it? "Documented" appears only where a source explicitly connects the outcome to BetaNYC or this roadmap; advocacy on the same topic without such a source is listed as engagement, not credit. Statuses reflect the public record as of July 17, 2026. Found something we missed? <a href="https://github.com/BetaNYC/peoples-roadmap-nyc/issues" target="_blank">Open an issue.</a></p>
+
+      <p class="lead">The testimony, the tools, and the trainings behind these rows run on community support. <a class="btn btn-large btn-primary" href="https://www.beta.nyc/donate/" target="_blank">Support our work</a></p>
+
+      <!-- FOOTER -->
+      <footer>
+        <p>This code was build by <a href="http://codeforhamptonroads.org" target="_blank">Code for Hampton Roads</a> and is maintained by <a href="https://github.com/betanyc" target="_blank">BetaNYC</a>. Site Design Based on <a href="http://twitter.github.com/bootstrap">Bootstrap</a>, Some Images Provided by <a href="http://thenounproject.com">The Noun Project</a> and <a href = "http://www.flickr.com/photos/namoscato/">Nick Amoscato</a>.</p>
+      </footer>
+
+    </div><!-- /.container -->
+
+  </body>
+</html>


### PR DESCRIPTION
Lane 2, artifact 1 of 2: a public scorecard page at `/scorecard.html`, linked from the nav and the hero's 2026 postscript.

## What's on the page

- All 34 recommendations in a status table: Enacted / Adopted / Partial / Superseded / Not realized, a one-line "what happened," BetaNYC's role, and one primary source per row (intro.nyc for legislation, nyc.gov, city program pages, Wayback for dead-era sources)
- The August 2014 mayoral press-release quote naming this roadmap as the source of the City Record demand (Wayback-verified)
- Headline count: 11 fully realized, 18 partial, 5 not realized; 16+ local laws and a Charter amendment
- Method note distinguishing documented credit from engagement, an "open an issue" correction path, and a single donate CTA
- Same Bootstrap 2.3 shell, style.css, and footer as the main page; no analytics

## Verification

Rendered locally over HTTP: styling, status badges, legend, blockquote, and table striping confirmed by screenshot; full content order and page geometry (no overflow, footer flush at document end) confirmed via DOM audit. All statuses and links trace to the 2026-07-17 impact analysis, which was cross-checked against the internal Roadmap Scorecard and primary sources.

## Before merging

Draft on purpose: this is public-facing BetaNYC copy, so it should get a `/qa-check` pass and Noel's read. A companion "Roadmap at 13" blog draft for beta.nyc is staged in the workspace; publishing that after this merges gives the hero and blog a resolving scorecard link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)